### PR TITLE
Add missing dependencies which prevent oedialect to work after fresh install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ setuptools.setup(
         'sqlalchemy >= 1.2.0',
         'requests >= 2.13',
         'psycopg2-binary',
-        'geoalchemy2'
+        'geoalchemy2',
+        'shapely',
+        'python-dateutil'
     ],
     keywords=['postgres', 'open', 'energy', 'database', 'sql', 'rest'],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,12 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url='https://github.com/openego/oedialect',
     packages=setuptools.find_packages(exclude=["test"]),
-    install_requires=['sqlalchemy >= 1.2.0',
-                      'requests >= 2.13'],
+    install_requires=[
+        'sqlalchemy >= 1.2.0',
+        'requests >= 2.13',
+        'psycopg2-binary',
+        'geoalchemy2'
+    ],
     keywords=['postgres', 'open', 'energy', 'database', 'sql', 'rest'],
     entry_points={
      'sqlalchemy.dialects': [


### PR DESCRIPTION
I don't know if we should also specify the version of psycopg2 or geoalchemy which should be installed.

On my laptop (linux)
`pip install psycopg2`
did not work
I had to do 
`pip install psycopg2-binary`